### PR TITLE
Fixed: Use of shadowed variable

### DIFF
--- a/cmd/ocfl/main.go
+++ b/cmd/ocfl/main.go
@@ -88,9 +88,9 @@ func userName() string {
 		return mainOpts.user
 	}
 
-	user, err := user.Current()
-	if err == nil && user.Name != "" {
-		return user.Name
+	sysUser, err := user.Current()
+	if err == nil && sysUser.Name != "" {
+		return sysUser.Name
 	}
 
 	// Last ditch, on Windows


### PR DESCRIPTION
The `user` variable shadowed the name from the `user` package. This PR renames the local variable to `sysUser` to clarify its origins.